### PR TITLE
Do not automatically set the origin header in websocket connections

### DIFF
--- a/src/Rfc6455Connector.php
+++ b/src/Rfc6455Connector.php
@@ -105,14 +105,6 @@ final class Rfc6455Connector implements Connector
         $request->setTlsHandshakeTimeout($handshake->getTlsHandshakeTimeout());
         $request->setHeaderSizeLimit($handshake->getHeaderSizeLimit());
 
-        if (!$request->hasHeader('origin')) {
-            $origin = $uri
-                ->withUserInfo('')
-                ->withPath('')
-                ->withQuery('');
-            $request->setHeader('origin', (string) $origin);
-        }
-
         $extensions = \array_column(Http\parseFieldValueComponents($request, 'sec-websocket-extensions'), 0, 0);
 
         if ($handshake->getOptions()->isCompressionEnabled() && \extension_loaded('zlib')) {


### PR DESCRIPTION
The v2 branch is currently setting the `origin` header even if not explicitly requested:
https://github.com/amphp/websocket-client/blob/b2ce5a8a7a4a47e253f1bb5dd6539cfd2488e201/src/Rfc6455Connector.php#L108-L114
However, this causes issues for web services that do not expect an `origin` header: https://github.com/discord/discord-api-docs/issues/4312#issuecomment-1040660416.  This could also be implemented as an option in Amp\Websocket\Options (https://github.com/amphp/websocket/blob/9d6e010f2367ddd19d7050f1755f7e8684e83c56/src/Options.php) to retain the current behavior by default.