### PR TITLE
Rename `parseFieldValueComponents` to `parseMultipleHeaderFields`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "php": ">=8.1",
         "amphp/amp": "^3",
         "amphp/byte-stream": "^2",
-        "amphp/http": "^2-dev",
+        "amphp/http": "^2",
         "amphp/http-client": "^5",
         "amphp/socket": "^2",
         "amphp/websocket": "^2",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "revolt/event-loop": "^1 || ^0.2.4"
     },
     "require-dev": {
-        "amphp/http-server": "^3",
+        "amphp/http-server": "3.x-dev",
         "amphp/websocket-server": "^3",
         "amphp/phpunit-util": "^3",
         "amphp/php-cs-fixer-config": "^2",

--- a/src/Rfc6455Connector.php
+++ b/src/Rfc6455Connector.php
@@ -71,7 +71,7 @@ final class Rfc6455Connector implements WebsocketConnector
                 return;
             }
 
-            $extensions = \array_column(Http\parseFieldValueComponents($response, 'sec-websocket-extensions') ?? [], 0, 0);
+            $extensions = \array_column(Http\parseMultipleHeaderFields($response, 'sec-websocket-extensions') ?? [], 0, 0);
 
             foreach ($extensions as $extension) {
                 if ($compressionContext = $compressionContextFactory?->fromServerHeader($extension)) {
@@ -111,7 +111,7 @@ final class Rfc6455Connector implements WebsocketConnector
         $request->setTlsHandshakeTimeout($handshake->getTlsHandshakeTimeout());
         $request->setHeaderSizeLimit($handshake->getHeaderSizeLimit());
 
-        $extensions = \array_column(Http\parseFieldValueComponents($request, 'sec-websocket-extensions') ?? [], 0, 0);
+        $extensions = \array_column(Http\parseMultipleHeaderFields($request, 'sec-websocket-extensions') ?? [], 0, 0);
 
         if ($this->compressionContextFactory && \extension_loaded('zlib')) {
             $extensions[] = $this->compressionContextFactory->createRequestHeader();

--- a/src/Rfc6455Connector.php
+++ b/src/Rfc6455Connector.php
@@ -71,7 +71,7 @@ final class Rfc6455Connector implements WebsocketConnector
                 return;
             }
 
-            $extensions = \array_column(Http\parseMultipleHeaderFields($response, 'sec-websocket-extensions') ?? [], 0, 0);
+            $extensions = \array_column(Http\parseHeaderTokens($response, 'sec-websocket-extensions') ?? [], 0, 0);
 
             foreach ($extensions as $extension) {
                 if ($compressionContext = $compressionContextFactory?->fromServerHeader($extension)) {
@@ -111,7 +111,7 @@ final class Rfc6455Connector implements WebsocketConnector
         $request->setTlsHandshakeTimeout($handshake->getTlsHandshakeTimeout());
         $request->setHeaderSizeLimit($handshake->getHeaderSizeLimit());
 
-        $extensions = \array_column(Http\parseMultipleHeaderFields($request, 'sec-websocket-extensions') ?? [], 0, 0);
+        $extensions = \array_column(Http\parseHeaderTokens($request, 'sec-websocket-extensions') ?? [], 0, 0);
 
         if ($this->compressionContextFactory && \extension_loaded('zlib')) {
             $extensions[] = $this->compressionContextFactory->createRequestHeader();


### PR DESCRIPTION
compatibility to http v2.0.0