### PR TITLE
Fix missing semicolon in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $connectionFactory = new Rfc6455ConnectionFactory(
 
 $connector = new Rfc6455Connector($connectionFactory);
 
-$handshake = new WebsocketHandshake('wss://example.com/websocket')
+$handshake = new WebsocketHandshake('wss://example.com/websocket');
 $connection = $connector->connect($handshake);
 ```
 


### PR DESCRIPTION
This PR adds a missing semicolon to the example of "Custom Connection Parameters" section in readme.