### PR TITLE
Make Rfc6455Connector compatible with PHP 8.4

### DIFF
--- a/src/Rfc6455Connector.php
+++ b/src/Rfc6455Connector.php
@@ -31,7 +31,7 @@ final class Rfc6455Connector implements WebsocketConnector
      */
     public function __construct(
         private readonly WebsocketConnectionFactory $connectionFactory = new Rfc6455ConnectionFactory(),
-        HttpClient $httpClient = null,
+        ?HttpClient $httpClient = null,
         private readonly ?WebsocketCompressionContextFactory $compressionContextFactory = new Rfc7692CompressionFactory(),
     ) {
         $this->httpClient = $httpClient


### PR DESCRIPTION
Fixes this error:

```
Deprecated: Amp\Websocket\Client\Rfc6455Connector::__construct():
    Implicitly marking parameter $httpClient as nullable is deprecated,
    the explicit nullable type must be used instead in src/Rfc6455Connector.php on line 32
```