### PR TITLE
Fix League\Uri\Http deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -54,7 +54,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-dir)"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('**/composer.*') }}-${{ matrix.composer-flags }}

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "amphp/http-client": "^5",
         "amphp/socket": "^2.2",
         "amphp/websocket": "^2",
-        "league/uri": "^6.8|^7.1",
+        "league/uri": "^7.1",
         "psr/http-message": "^1|^2",
         "revolt/event-loop": "^1"
     },

--- a/src/WebsocketHandshake.php
+++ b/src/WebsocketHandshake.php
@@ -237,7 +237,7 @@ final class WebsocketHandshake extends HttpRequest
         if (\is_string($uri)) {
             try {
                 /** @psalm-suppress DeprecatedMethod Using deprecated method to support 6.x and 7.x of league/uri */
-                $uri = Uri\Http::createFromString($uri);
+                $uri = Uri\Http::new($uri);
             } catch (\Exception $exception) {
                 throw new \ValueError('Invalid Websocket URI provided', 0, $exception);
             }


### PR DESCRIPTION
Fixes this warning:
```
User Deprecated: Method League\Uri\Http::createFromString()
    is deprecated since league/uri:7.0.0, use League\Uri\Http::new() instead
```